### PR TITLE
Support UIAccessibility protocol

### DIFF
--- a/CollectionViewIndex/CollectionViewIndex.swift
+++ b/CollectionViewIndex/CollectionViewIndex.swift
@@ -62,6 +62,9 @@ public class CollectionViewIndex: UIControl {
         
         backgroundColor = UIColor(white: 1, alpha: 0.9)
         contentMode = .redraw
+        isAccessibilityElement = true
+        accessibilityTraits = UIAccessibilityTraitAdjustable
+        accessibilityLabel = NSLocalizedString("table index", comment: "title given to the section index control")
     }
 
     public required init?(coder aDecoder: NSCoder) {
@@ -215,4 +218,31 @@ public class CollectionViewIndex: UIControl {
         return CGSize(width: max(15, width + 4), height: size.height)
     }
 
+}
+
+// MARK: - UIAccessibility
+
+extension CollectionViewIndex {
+    public override func accessibilityIncrement() {
+        let newIndex = selectedIndex - 1
+        changeSection(newIndex)
+    }
+
+    public override func accessibilityDecrement() {
+        let newIndex = selectedIndex + 1
+        changeSection(newIndex)
+    }
+
+    private func changeSection(_ section: Int) {
+        guard section >= 0, section < indexTitles.count else { return }
+        _selectedIndex = section
+        sendActions(for: .valueChanged)
+        announceNewSection()
+    }
+
+    private func announceNewSection() {
+        let title =  indexTitles[selectedIndex]
+        let announcement = "\(title)".lowercased()
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, announcement)
+    }
 }


### PR DESCRIPTION
Currently, users using Voice Over are unable to take advantage of `CollectionViewIndex`. This Pull Request attempts to mirror the Voice Over support for the built in table view index control.

The only caveat is that the built in Voice Over reads table view index changes as "X (pause) selected", whereas this request simply reads the index title, e.g. "X".